### PR TITLE
Swap Resque::Helpers for ActiveSupport

### DIFF
--- a/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
+++ b/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
@@ -15,13 +15,12 @@
 #      config.restricted_before_queued = true
 #    end
 
+require 'active_support'
+
 module Resque
   module Plugins
     module ConcurrentRestriction
-      # Warning: The helpers module will be gone in Resque 2.x
-      # Resque::Helpers removed from Resque in 1.25, see:
-      # https://github.com/resque/resque/issues/1150#issuecomment-27942972
-      include Resque::Helpers
+      include ::ActiveSupport::Inflector
 
       # Allows configuring via class accessors
       class << self

--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.6.0"
+      VERSION = "0.6.1"
     end
   end
 end

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -2,7 +2,6 @@
 $:.push File.expand_path("../lib", __FILE__)
 require 'resque/plugins/concurrent_restriction/version'
 
-
 Gem::Specification.new do |s|
   s.name        = "resque-concurrent-restriction"
   s.version     = Resque::Plugins::ConcurrentRestriction::VERSION
@@ -21,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("resque", '~> 1.25')
+  s.add_dependency("activesupport", '~> 3.2')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')


### PR DESCRIPTION
I know it's just swapping out dependencies... but nonetheless it fixes
the deprecation warnings.
